### PR TITLE
Working with 3.3 of the JS API

### DIFF
--- a/d3Layer.js
+++ b/d3Layer.js
@@ -1,5 +1,7 @@
 dojo.provide("modules.d3Layer");
 
+dojo.require("esri.layers.graphics");
+
 dojo.declare("modules.d3Layer", esri.layers.GraphicsLayer, {
 
     constructor: function(url, options) {

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=7,IE=9" />
     <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no"/>
     <title>Esri <3 d3js</title>
-    <link rel="stylesheet" type="text/css" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.2/js/dojo/dijit/themes/tundra/tundra.css">
-    <link rel="stylesheet" href="http://servicesbeta.esri.com/jsapi/arcgis/3.2/js/esri/css/esri.css" />
+    <link rel="stylesheet" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.3/js/esri/css/esri.css">
     <style type="text/css">
       html, body { 
         height: 100%; width: 100%;
@@ -43,7 +42,8 @@
       };
     </script>
     
-    <script src="http://servicesbeta.esri.com/jsapi/arcgis/3.2/"></script>
+    <!-- <script src="http://servicesbeta.esri.com/jsapi/arcgis/3.2/"></script> -->
+    <script src="http://serverapi.arcgisonline.com/jsapi/arcgis/3.3/"></script>
     <script src="http://d3js.org/d3.v3.min.js"></script>
     <script>
       dojo.require("esri.map");


### PR DESCRIPTION
Changes:
–removed link to tundra style sheet (3.3 uses a small zoom control by default so no need for the dojo theme to be included since the big slider isn't used)
–upgraded to 3.3
–added dojo.require("esri.layers.graphics"); to d3Layer.js

Background on the third change:  the graphics layer has been around since 1.0. Back then, modules were developed a bit different. Instead of matching the class name, modules were given more generic names and contained several classes. In this case, esri.layers.graphics contains GraphicsLayer as well as a few other supporting classes.
